### PR TITLE
change dll path for newer versions of dymo

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ var nodeDymoLib = path.join(libDir, 'NodeDymoLib.dll');
 var dymoLibPath = path.join('C:', 'Program Files (x86)', 'DYMO', 'DYMO Label Software', 'Framework', '.net4');
 dymoAssemblies = [ 'DYMO.Label.Framework.dll', 'DYMO.DLS.Runtime.dll', 'DYMO.Common.dll' ];
 
+if (!fs.existsSync(dymoLibPath + "/DYMO.LABEL.Framework.dll")) {
+	dymoLibPath =  path.join(dymoLibPath, "..");
+}
+
 var called = 0;
 
 var initDymoLib = function() {


### PR DESCRIPTION
Newer dymo versions (such as 8.7.3) have changed the directory for their dll fields. This will do a check to see if the dll files are in the specified directory, else go up one level in the path